### PR TITLE
fix: close remaining review gaps

### DIFF
--- a/core/client.py
+++ b/core/client.py
@@ -353,7 +353,10 @@ class TelegramClientWrapper:
                         return
 
             # ========== 慢速路径：完整初始化 ==========
-            await self.client.connect()
+            if not await self.ensure_connected():
+                logger.error("[Client] Telegram 客户端连接失败")
+                self._authorized = False
+                return
 
             # ========== 检查授权状态 ==========
             authorized = await self.client.is_user_authorized()

--- a/core/commands.py
+++ b/core/commands.py
@@ -659,6 +659,7 @@ class PluginCommands:
                 "api_hash",
                 "telegram_session",
                 "proxy",
+                "debug_enabled_default",
             ]
             root_display = {}
             for key in interesting_root_keys:
@@ -674,6 +675,8 @@ class PluginCommands:
                             display = f"已上传 {len(val)} 个 session 文件"
                     else:
                         display = "格式异常"
+                elif key == "debug_enabled_default":
+                    display = str(bool(val)) if val is not None else "<未设置>"
                 else:
                     display = self.mask_sensitive(val, key)  # 脱敏
 
@@ -832,7 +835,7 @@ class PluginCommands:
                 ("api_id", "Telegram API ID（纯数字，从 my.telegram.org 获取）"),
                 ("api_hash", "Telegram API Hash（字符串，从 my.telegram.org 获取）"),
                 ("proxy", "代理地址（例如 http://127.0.0.1:7890 或 socks5://...）"),
-                ("debug_enabled_default", "QQ 发送诊断日志默认开关（true/false）"),
+                ("debug_enabled_default", "QQ 发送诊断日志默认开关(true/false)"),
             ]
 
         elif target_clean == "global":

--- a/core/commands.py
+++ b/core/commands.py
@@ -832,6 +832,7 @@ class PluginCommands:
                 ("api_id", "Telegram API ID（纯数字，从 my.telegram.org 获取）"),
                 ("api_hash", "Telegram API Hash（字符串，从 my.telegram.org 获取）"),
                 ("proxy", "代理地址（例如 http://127.0.0.1:7890 或 socks5://...）"),
+                ("debug_enabled_default", "QQ 发送诊断日志默认开关（true/false）"),
             ]
 
         elif target_clean == "global":
@@ -936,6 +937,7 @@ class PluginCommands:
                 "api_id": "纯数字，例如：1234567",
                 "api_hash": "字符串，例如：a1b2c3d4e5f6g7h8i9j0",
                 "proxy": "代理地址，例如：http://127.0.0.1:7890",
+                "debug_enabled_default": "true / false / 开启 / 关闭",
             }
         elif target_clean == "global":
             mapping = {
@@ -1246,6 +1248,7 @@ class PluginCommands:
                 "api_id",
                 "api_hash",
                 "proxy",
+                "debug_enabled_default",
             }
 
             if field not in allowed_root_fields:
@@ -1274,6 +1277,8 @@ class PluginCommands:
                     value = []
                 else:
                     value = [x.strip() for x in value_str.split(",") if x.strip()]
+            elif field == "debug_enabled_default":
+                value = value_str.lower() in ("true", "1", "yes", "y", "开启", "开", "是")
             else:
                 value = value_str
 

--- a/core/commands.py
+++ b/core/commands.py
@@ -1278,7 +1278,19 @@ class PluginCommands:
                 else:
                     value = [x.strip() for x in value_str.split(",") if x.strip()]
             elif field == "debug_enabled_default":
-                value = value_str.lower() in ("true", "1", "yes", "y", "开启", "开", "是")
+                normalized_value = value_str.lower()
+                true_tokens = {"true", "1", "yes", "y", "开启", "开", "是"}
+                false_tokens = {"false", "0", "no", "n", "关闭", "关", "否"}
+                if normalized_value in true_tokens:
+                    value = True
+                elif normalized_value in false_tokens:
+                    value = False
+                else:
+                    field_help = self._get_single_field_help(target, field)
+                    yield event.plain_result(
+                        f"❌ 值格式错误：root.{field} = {value_str!r}\n\n格式要求：\n{field_help}"
+                    )
+                    return
             else:
                 value = value_str
 

--- a/core/senders/qq.py
+++ b/core/senders/qq.py
@@ -522,9 +522,21 @@ class QQSender:
             )
 
         context_target_sessions = self._resolve_context_target_sessions(qq_targets)
+        real_batches = self._flatten_batches(batches)
+
+        if not real_batches:
+            logger.debug("[QQSender] 展平后无有效批次，跳过发送")
+            return QQSendSummary()
 
         if not context_target_sessions:
-            return QQSendSummary()
+            failed_batch_indexes = tuple(range(len(real_batches)))
+            return QQSendSummary(
+                failed_batch_indexes=failed_batch_indexes,
+                error_types={
+                    batch_index: "unresolved_target_session"
+                    for batch_index in failed_batch_indexes
+                },
+            )
 
         forward_cfg = self.config.get("forward_config", {})
         qq_merge_threshold = forward_cfg.get("qq_merge_threshold", 0)
@@ -533,12 +545,6 @@ class QQSender:
             target_circuit_fail_threshold,
             target_circuit_cooldown_sec,
         ) = self._resolve_send_limits(forward_cfg)
-
-        real_batches = self._flatten_batches(batches)
-
-        if not real_batches:
-            logger.debug("[QQSender] 展平后无有效批次，跳过发送")
-            return QQSendSummary()
 
         logger.debug(
             f"[QQSender] 接收到 {len(batches)} 批次，展平后 {len(real_batches)} 个逻辑批次"

--- a/core/senders/qq.py
+++ b/core/senders/qq.py
@@ -525,7 +525,7 @@ class QQSender:
         real_batches = self._flatten_batches(batches)
 
         if not real_batches:
-            logger.debug("[QQSender] 展平后无有效批次，跳过发送")
+            logger.debug("[QQSender] 展平后无有效批次, 跳过发送")
             return QQSendSummary()
 
         if not context_target_sessions:

--- a/core/senders/qq_dispatcher.py
+++ b/core/senders/qq_dispatcher.py
@@ -144,8 +144,9 @@ async def dispatch_processed_batches_to_targets(
                         )
                         for batch_data in chunk_batches
                     )
+                    send_each_batch = len(chunk_batches) == 1 or chunk_has_special_media
                     try:
-                        if len(chunk_batches) == 1 or chunk_has_special_media:
+                        if send_each_batch:
                             for batch_data in chunk_batches:
                                 await send_processed_batch_fn(
                                     batch_data=batch_data,
@@ -180,7 +181,7 @@ async def dispatch_processed_batches_to_targets(
                                 target_session=target_session,
                                 allow_forward_nodes=False,
                             )
-                        if not (len(chunk_batches) == 1 or chunk_has_special_media):
+                        if not send_each_batch:
                             for batch_index in chunk_batch_indexes:
                                 target_successes[batch_index].add(target_session)
                             record_target_success(target_session)

--- a/core/senders/qq_dispatcher.py
+++ b/core/senders/qq_dispatcher.py
@@ -155,6 +155,10 @@ async def dispatch_processed_batches_to_targets(
                                     target_session=target_session,
                                     allow_forward_nodes=False,
                                 )
+                                target_successes[batch_data["batch_index"]].add(
+                                    target_session
+                                )
+                            record_target_success(target_session)
                         elif len(chunk_nodes) > 1:
                             nodes_list = [
                                 Node(uin=self_id, name=node_name, content=nc)
@@ -176,9 +180,10 @@ async def dispatch_processed_batches_to_targets(
                                 target_session=target_session,
                                 allow_forward_nodes=False,
                             )
-                        for batch_index in chunk_batch_indexes:
-                            target_successes[batch_index].add(target_session)
-                        record_target_success(target_session)
+                        if not (len(chunk_batches) == 1 or chunk_has_special_media):
+                            for batch_index in chunk_batch_indexes:
+                                target_successes[batch_index].add(target_session)
+                            record_target_success(target_session)
                         consecutive_failures = 0
                         if log_policy is not None:
                             log_policy.log_merge_send(

--- a/relogin.py
+++ b/relogin.py
@@ -60,30 +60,34 @@ async def _async_input(prompt: str) -> str:
 
 async def main():
     print(f"正在连接... (Session路径: {SESSION_FILE})")
-    client = TelegramClient(SESSION_FILE, api_id, api_hash, proxy=proxy_setting)
+    client = None
+    try:
+        client = TelegramClient(SESSION_FILE, api_id, api_hash, proxy=proxy_setting)
 
-    await client.connect()
+        await client.connect()
 
-    if not await client.is_user_authorized():
-        print("未授权，开始登录流程...")
-        phone = await _async_input("请输入手机号 (带国际区号, 如 +86138...): ")
-        await client.send_code_request(phone)
+        if not await client.is_user_authorized():
+            print("未授权，开始登录流程...")
+            phone = await _async_input("请输入手机号 (带国际区号, 如 +86138...): ")
+            await client.send_code_request(phone)
 
-        code = await _async_input("请输入您收到的验证码: ")
-        try:
-            await client.sign_in(phone, code)
-        except SessionPasswordNeededError:
-            pw = await _async_input("请输入两步验证密码: ")
-            await client.sign_in(password=pw)
-        except Exception as e:
-            print(f"登录失败: {e}")
-            return
+            code = await _async_input("请输入您收到的验证码: ")
+            try:
+                await client.sign_in(phone, code)
+            except SessionPasswordNeededError:
+                pw = await _async_input("请输入两步验证密码: ")
+                await client.sign_in(password=pw)
+            except Exception as e:
+                print(f"登录失败: {e}")
+                return
 
-    print("登录成功！")
-    me = await client.get_me()
-    print(f"当前用户: {me.first_name} (@{me.username})")
-    print("Session 文件已更新。现在您可以重启 AstrBot 了。")
-    await client.disconnect()
+        print("登录成功！")
+        me = await client.get_me()
+        print(f"当前用户: {me.first_name} (@{me.username})")
+        print("Session 文件已更新。现在您可以重启 AstrBot 了。")
+    finally:
+        if client is not None:
+            await client.disconnect()
 
 
 if __name__ == "__main__":

--- a/relogin.py
+++ b/relogin.py
@@ -37,7 +37,11 @@ if not os.path.exists(CONFIG_FILE):
 # 为了方便，请您直接在此处填入您的 API ID 和 Hash，或者我们尝试交互式输入
 print("=== Telegram Forwarder 重新登录助手 ===")
 
-api_id = input("请输入 API ID: ").strip()
+api_id_raw = input("请输入 API ID: ").strip()
+try:
+    api_id = int(api_id_raw)
+except ValueError:
+    raise SystemExit("API ID 必须是整数")
 api_hash = input("请输入 API Hash: ").strip()
 proxy_url = input(
     "请输入代理地址 (可选, 如 http://127.0.0.1:10801, 直接回车跳过): "

--- a/relogin.py
+++ b/relogin.py
@@ -87,7 +87,10 @@ async def main():
         print("Session 文件已更新。现在您可以重启 AstrBot 了。")
     finally:
         if client is not None:
-            await client.disconnect()
+            try:
+                await client.disconnect()
+            except Exception as e:
+                print(f"断开 Telegram 客户端连接失败（已忽略）: {e}")
 
 
 if __name__ == "__main__":

--- a/tests/test_client_session_schema.py
+++ b/tests/test_client_session_schema.py
@@ -514,10 +514,13 @@ def test_start_routes_connection_through_ensure_connected():
     client.get_dialogs = AsyncMock()
     wrapper.client = client
 
-    client_module.get_auth_cache().clear()
+    auth_cache = client_module.get_auth_cache()
+    auth_cache.clear()
 
     asyncio.run(wrapper.start())
 
     wrapper.ensure_connected.assert_awaited_once_with()
     client.connect.assert_not_awaited()
     client.get_dialogs.assert_awaited_once_with(limit=None)
+    assert wrapper._authorized is True
+    auth_cache.clear()

--- a/tests/test_client_session_schema.py
+++ b/tests/test_client_session_schema.py
@@ -496,3 +496,28 @@ def test_ensure_connected_returns_false_when_second_connect_fails_after_rebuild(
     )
     wrapper._init_client.assert_called_once_with()
     new_client.connect.assert_awaited_once_with()
+
+
+def test_start_routes_connection_through_ensure_connected():
+    client_module = load_client_module()
+    wrapper = object.__new__(client_module.TelegramClientWrapper)
+    wrapper.config = {}
+    wrapper.plugin_data_dir = "synthetic/session"
+    wrapper._authorized = False
+    wrapper._session_path = MagicMock(return_value="synthetic/session/user_session")
+    wrapper.ensure_connected = AsyncMock(return_value=True)
+
+    client = MagicMock()
+    client.is_connected.return_value = False
+    client.connect = AsyncMock()
+    client.is_user_authorized = AsyncMock(return_value=True)
+    client.get_dialogs = AsyncMock()
+    wrapper.client = client
+
+    client_module.get_auth_cache().clear()
+
+    asyncio.run(wrapper.start())
+
+    wrapper.ensure_connected.assert_awaited_once_with()
+    client.connect.assert_not_awaited()
+    client.get_dialogs.assert_awaited_once_with(limit=None)

--- a/tests/test_commands_debug.py
+++ b/tests/test_commands_debug.py
@@ -227,6 +227,19 @@ class TestPluginCommandsDebug:
         assert "/tg debug <on|off|status>" in results[0]
 
     @pytest.mark.asyncio
+    async def test_get_root_reports_debug_enabled_default(self) -> None:
+        commands = make_commands(config_default=True, qq_sender=FakeQQSender())
+        event = make_event()
+
+        results = []
+        async for result in commands.get_config(event, "root"):
+            results.append(result)
+
+        assert len(results) == 1
+        assert "debug_enabled_default" in results[0]
+        assert "True" in results[0]
+
+    @pytest.mark.asyncio
     async def test_set_root_debug_enabled_default_updates_config(self) -> None:
         commands = make_commands(qq_sender=FakeQQSender())
         commands.context._star_manager.reload = AsyncMock(return_value=(True, None))
@@ -256,3 +269,4 @@ class TestPluginCommandsDebug:
         assert "maybe" in results[0]
         assert "debug_enabled_default" not in commands.config
         commands.config.save_config.assert_not_called()
+        commands.context._star_manager.reload.assert_not_called()

--- a/tests/test_commands_debug.py
+++ b/tests/test_commands_debug.py
@@ -240,3 +240,19 @@ class TestPluginCommandsDebug:
         commands.config.save_config.assert_called_once_with()
         assert "已修改根配置 debug_enabled_default" in results[0]
         assert "已自动重载插件" in results[1]
+
+    @pytest.mark.asyncio
+    async def test_set_root_debug_enabled_default_rejects_unknown_token(self) -> None:
+        commands = make_commands(qq_sender=FakeQQSender())
+        commands.config.pop("debug_enabled_default", None)
+        event = make_event()
+
+        results = []
+        async for result in commands.set_config(event, "root debug_enabled_default maybe"):
+            results.append(result)
+
+        assert "❌ 值格式错误" in results[0]
+        assert "debug_enabled_default" in results[0]
+        assert "maybe" in results[0]
+        assert "debug_enabled_default" not in commands.config
+        commands.config.save_config.assert_not_called()

--- a/tests/test_commands_debug.py
+++ b/tests/test_commands_debug.py
@@ -6,7 +6,7 @@ from functools import lru_cache
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -25,6 +25,12 @@ class PhoneCodeInvalidError(Exception):
 
 class SessionPasswordNeededError(Exception):
     pass
+
+
+class FakeConfig(dict):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.save_config = MagicMock()
 
 
 class FakeQQSender:
@@ -95,7 +101,7 @@ def make_commands(
     *, config_default: bool = False, qq_sender: FakeQQSender | None = None
 ) -> Any:
     commands_module = load_commands_module()
-    config = {"debug_enabled_default": config_default}
+    config = FakeConfig({"debug_enabled_default": config_default})
     forwarder = SimpleNamespace(qq_sender=qq_sender)
     if qq_sender is not None:
         qq_sender.config = config
@@ -219,3 +225,18 @@ class TestPluginCommandsDebug:
 
         assert len(results) == 1
         assert "/tg debug <on|off|status>" in results[0]
+
+    @pytest.mark.asyncio
+    async def test_set_root_debug_enabled_default_updates_config(self) -> None:
+        commands = make_commands(qq_sender=FakeQQSender())
+        commands.context._star_manager.reload = AsyncMock(return_value=(True, None))
+        event = make_event()
+
+        results = []
+        async for result in commands.set_config(event, "root debug_enabled_default true"):
+            results.append(result)
+
+        assert commands.config["debug_enabled_default"] is True
+        commands.config.save_config.assert_called_once_with()
+        assert "已修改根配置 debug_enabled_default" in results[0]
+        assert "已自动重载插件" in results[1]

--- a/tests/test_qq_sender.py
+++ b/tests/test_qq_sender.py
@@ -74,6 +74,61 @@ async def test_big_merge_fallback_skips_batches_already_marked_success(qq_module
     assert result.target_successes[1] == {"aiocqhttp:GroupMessage:1"}
 
 
+@pytest.mark.asyncio
+async def test_special_media_chunk_records_success_before_later_batch_failure(qq_module):
+    send_calls: list[int] = []
+
+    async def send_processed_batch_fn(**kwargs):
+        batch_index = kwargs["batch_data"]["batch_index"]
+        send_calls.append(batch_index)
+        if batch_index == 1:
+            raise RuntimeError("second batch failed")
+
+    processed_batches = [
+        {
+            "batch_index": 0,
+            "nodes_data": [[qq_module.File(file="/tmp/a.bin", name="a.bin")]],
+            "contains_audio": False,
+        },
+        {
+            "batch_index": 1,
+            "nodes_data": [[qq_module.File(file="/tmp/b.bin", name="b.bin")]],
+            "contains_audio": False,
+        },
+    ]
+    target_successes = {0: set(), 1: set()}
+    lock = asyncio.Lock()
+
+    result = await qq_module.dispatch_processed_batches_to_targets(
+        context_target_sessions=["aiocqhttp:GroupMessage:1"],
+        real_batches=[[object()], [object()]],
+        processed_batches=processed_batches,
+        target_successes=target_successes,
+        target_failures={},
+        deferred_batch_indexes=set(),
+        use_big_merge=True,
+        is_mixed_big_merge=False,
+        forward_cfg={"qq_merge_chunk_size": 10, "qq_merge_chunk_delay": 0},
+        self_id=1,
+        node_name="bot",
+        get_lock=lambda target: lock,
+        target_is_open=lambda target, now_ts: False,
+        record_target_success=lambda target: None,
+        record_target_failure=lambda target, **kwargs: None,
+        classify_send_error=lambda exc: str(exc),
+        send_processed_batch_fn=send_processed_batch_fn,
+        send_message_fn=AsyncMock(),
+        fail_fast_limit=10,
+        target_circuit_fail_threshold=3,
+        target_circuit_cooldown_sec=60,
+        log_policy=None,
+    )
+
+    assert send_calls == [0, 1, 1]
+    assert result.target_successes[0] == {"aiocqhttp:GroupMessage:1"}
+    assert result.target_failures == {1: "second batch failed"}
+
+
 class TestDispatchMediaFile:
     def test_dispatch_by_extension(self, sender):
         cases = [
@@ -1617,6 +1672,32 @@ class TestSendSummary:
         assert summary.acked_batch_indexes == ()
         assert set(summary.failed_batch_indexes) == {0, 1}
         assert summary.error_types == {0: "timeout", 1: "timeout"}
+
+    @pytest.mark.asyncio
+    async def test_send_marks_numeric_targets_failed_when_platform_id_unresolved(self, sender):
+        sender.context.send_message = AsyncMock()
+        sender.config = {"forward_config": {"qq_merge_threshold": 99}}
+        sender.platform_id = None
+        sender._bootstrap_qq_runtime = AsyncMock()
+
+        msg1 = type("Msg", (), {"id": 1, "text": "a", "reply_to": None})()
+        msg2 = type("Msg", (), {"id": 2, "text": "b", "reply_to": None})()
+
+        summary = await sender.send(
+            batches=[[msg1], [msg2]],
+            src_channel="demo",
+            display_name="demo",
+            effective_cfg={"effective_target_qq_sessions": ["123456"]},
+            involved_channels=None,
+        )
+
+        sender.context.send_message.assert_not_awaited()
+        assert summary.acked_batch_indexes == ()
+        assert summary.failed_batch_indexes == (0, 1)
+        assert summary.error_types == {
+            0: "unresolved_target_session",
+            1: "unresolved_target_session",
+        }
 
     @pytest.mark.asyncio
     async def test_send_marks_preprocess_empty_batch_with_error_type(self, sender):

--- a/tests/test_relogin.py
+++ b/tests/test_relogin.py
@@ -1,0 +1,67 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class SessionPasswordNeededError(Exception):
+    pass
+
+
+def load_relogin_module(client_factory: MagicMock):
+    root = Path(__file__).resolve().parents[1]
+    module_path = root / "relogin.py"
+    module_name = "astrbot_plugin_telegram_forwarder.relogin"
+
+    stubbed_modules = {
+        "socks": SimpleNamespace(HTTP=1, SOCKS5=2),
+        "telethon": SimpleNamespace(TelegramClient=client_factory),
+        "telethon.errors": SimpleNamespace(
+            SessionPasswordNeededError=SessionPasswordNeededError
+        ),
+    }
+
+    with patch.dict(sys.modules, stubbed_modules):
+        sys.modules.pop(module_name, None)
+        spec = importlib.util.spec_from_file_location(module_name, module_path)
+        mod = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        with patch("builtins.input", side_effect=["123456", "hash", ""]):
+            spec.loader.exec_module(mod)
+        return mod
+
+
+@pytest.mark.asyncio
+async def test_relogin_disconnects_when_sign_in_raises():
+    client = MagicMock()
+    client.connect = AsyncMock()
+    client.disconnect = AsyncMock()
+    client.is_user_authorized = AsyncMock(return_value=False)
+    client.send_code_request = AsyncMock()
+    client.sign_in = AsyncMock(side_effect=RuntimeError("login failed"))
+
+    relogin_module = load_relogin_module(MagicMock(return_value=client))
+    relogin_module._async_input = AsyncMock(side_effect=["+8613800000000", "12345"])
+
+    await relogin_module.main()
+
+    client.disconnect.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_relogin_disconnects_when_get_me_raises():
+    client = MagicMock()
+    client.connect = AsyncMock()
+    client.disconnect = AsyncMock()
+    client.is_user_authorized = AsyncMock(return_value=True)
+    client.get_me = AsyncMock(side_effect=RuntimeError("session check failed"))
+
+    relogin_module = load_relogin_module(MagicMock(return_value=client))
+
+    with pytest.raises(RuntimeError, match="session check failed"):
+        await relogin_module.main()
+
+    client.disconnect.assert_awaited_once_with()

--- a/tests/test_relogin.py
+++ b/tests/test_relogin.py
@@ -65,3 +65,19 @@ async def test_relogin_disconnects_when_get_me_raises():
         await relogin_module.main()
 
     client.disconnect.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_relogin_preserves_original_error_when_disconnect_raises():
+    client = MagicMock()
+    client.connect = AsyncMock()
+    client.disconnect = AsyncMock(side_effect=RuntimeError("disconnect failed"))
+    client.is_user_authorized = AsyncMock(return_value=True)
+    client.get_me = AsyncMock(side_effect=RuntimeError("session check failed"))
+
+    relogin_module = load_relogin_module(MagicMock(return_value=client))
+
+    with pytest.raises(RuntimeError, match="session check failed"):
+        await relogin_module.main()
+
+    client.disconnect.assert_awaited_once_with()

--- a/tests/test_relogin.py
+++ b/tests/test_relogin.py
@@ -11,7 +11,9 @@ class SessionPasswordNeededError(Exception):
     pass
 
 
-def load_relogin_module(client_factory: MagicMock):
+def load_relogin_module(
+    client_factory: MagicMock, inputs: list[str] | None = None
+):
     root = Path(__file__).resolve().parents[1]
     module_path = root / "relogin.py"
     module_name = "astrbot_plugin_telegram_forwarder.relogin"
@@ -29,9 +31,14 @@ def load_relogin_module(client_factory: MagicMock):
         spec = importlib.util.spec_from_file_location(module_name, module_path)
         mod = importlib.util.module_from_spec(spec)
         assert spec.loader is not None
-        with patch("builtins.input", side_effect=["123456", "hash", ""]):
+        with patch("builtins.input", side_effect=inputs or ["123456", "hash", ""]):
             spec.loader.exec_module(mod)
         return mod
+
+
+def test_relogin_exits_when_api_id_is_not_integer():
+    with pytest.raises(SystemExit, match="API ID 必须是整数"):
+        load_relogin_module(MagicMock(), inputs=["not-int", "hash", ""])
 
 
 @pytest.mark.asyncio
@@ -43,11 +50,18 @@ async def test_relogin_disconnects_when_sign_in_raises():
     client.send_code_request = AsyncMock()
     client.sign_in = AsyncMock(side_effect=RuntimeError("login failed"))
 
-    relogin_module = load_relogin_module(MagicMock(return_value=client))
+    client_factory = MagicMock(return_value=client)
+    relogin_module = load_relogin_module(client_factory)
     relogin_module._async_input = AsyncMock(side_effect=["+8613800000000", "12345"])
 
     await relogin_module.main()
 
+    client_factory.assert_called_once_with(
+        relogin_module.SESSION_FILE,
+        123456,
+        "hash",
+        proxy=None,
+    )
     client.disconnect.assert_awaited_once_with()
 
 


### PR DESCRIPTION
## Summary
- carry over only the two review fixes that are still missing from `main`
- fail QQ batches when numeric targets cannot resolve and fix `/tg set root debug_enabled_default`
- ensure Telegram relogin/client startup always clean up and route reconnects through wrong-session self-healing

## Test plan
- [x] `pytest tests/ -v`
- [x] verified branch against `origin/main` with `git cherry -v`

## Notes
- This PR replaces #23 with a minimal diff because earlier pieces of that branch already landed in `main` under different SHAs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a root-level setting `debug_enabled_default` manageable via `/tg set` and shown by `/tg get`.

* **Bug Fixes**
  * Startup now defers to a centralized connection check to avoid proceeding on failed connections.
  * Unresolved target sessions are now marked as failed instead of producing empty results.
  * Batch dispatch bookkeeping improved so per-batch successes/failures are recorded correctly.

* **Tests**
  * Added/expanded tests for startup connection flow, relogin teardown, command parsing, and QQ dispatch behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->