### PR TITLE
fix: guard QQ media forwarding edge cases

### DIFF
--- a/core/downloader.py
+++ b/core/downloader.py
@@ -41,22 +41,30 @@ class MediaDownloader:
         ):
             return local_files
 
-        # 检查大小限制 (图片除外)
+        # 检查大小限制
         is_photo = bool(msg.photo)
-        if not is_photo and max_size_mb > 0:
-            file_size = 0
-            if hasattr(msg.media, "document") and hasattr(msg.media.document, "size"):
-                file_size = msg.media.document.size
-            elif hasattr(msg.file, "size"):
-                file_size = msg.file.size
-
-            if file_size > max_size_mb * 1024 * 1024:
-                logger.info(
-                    f"[Downloader] 消息 {msg.id} 中的文件过大 ({file_size / 1024 / 1024:.2f} MB > {max_size_mb} MB)，跳过下载。"
-                )
-                return local_files
-
         is_video = bool(msg.video)
+
+        file_size = 0
+        if hasattr(msg.media, "document") and hasattr(msg.media.document, "size"):
+            file_size = msg.media.document.size
+        elif hasattr(msg, "file") and hasattr(msg.file, "size"):
+            file_size = msg.file.size
+
+        # QQ 平台对视频上传大小限制更严格，超过阈值直接跳过避免后续 rich media transfer failed
+        qq_video_max_mb = 100
+        if is_video and file_size > qq_video_max_mb * 1024 * 1024:
+            logger.info(
+                f"[Downloader] 消息 {msg.id} 视频过大 ({file_size / 1024 / 1024:.2f} MB > {qq_video_max_mb} MB)，跳过下载。"
+            )
+            return local_files
+
+        if not is_photo and max_size_mb > 0 and file_size > max_size_mb * 1024 * 1024:
+            logger.info(
+                f"[Downloader] 消息 {msg.id} 中的文件过大 ({file_size / 1024 / 1024:.2f} MB > {max_size_mb} MB)，跳过下载。"
+            )
+            return local_files
+
         is_audio = bool(msg.audio or msg.voice)
         is_file = bool(msg.file)
 

--- a/core/senders/qq_media.py
+++ b/core/senders/qq_media.py
@@ -101,6 +101,12 @@ def dispatch_media_file(
         return [record]
     if ext in (".mp4", ".mkv", ".mov", ".webm", ".avi"):
         mapped = map_path(fpath)
+        if mapped != fpath and not os.path.isfile(mapped) and os.path.isfile(fpath):
+            logger.warning(
+                f"[QQSender] Mapped video path not found, fallback to source path: "
+                f"source_path={fpath!r}, mapped_path={mapped!r}"
+            )
+            mapped = fpath
         if mapped != fpath:
             video = Video(file=_as_file_uri(mapped))
         else:
@@ -124,6 +130,12 @@ def dispatch_media_file(
             )
         return [video]
     mapped = map_path(fpath)
+    if mapped != fpath and not os.path.isfile(mapped) and os.path.isfile(fpath):
+        logger.warning(
+            f"[QQSender] Mapped file path not found, fallback to source path: "
+            f"source_path={fpath!r}, mapped_path={mapped!r}"
+        )
+        mapped = fpath
     component = _patch_file_to_dict(
         File(
             file=mapped,

--- a/tests/test_qq_sender.py
+++ b/tests/test_qq_sender.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import importlib.util
+import os
 import shutil
 import uuid
 import zipfile
@@ -163,6 +164,34 @@ class TestDispatchMediaFile:
         assert type(result[0]).__name__ == "Video"
         assert result[0].file == "file:///mapped/tmp/video.mp4"
 
+    def test_video_path_mapping_falls_back_to_source_when_mapped_path_missing(
+        self, qq_module, monkeypatch
+    ):
+        source_path = "/tmp/video.mp4"
+        mapped_path = "/mapped/video.mp4"
+
+        def fake_isfile(path):
+            if path == source_path:
+                return True
+            if path == mapped_path:
+                return False
+            return False
+
+        monkeypatch.setattr(
+            qq_module.dispatch_media_file.__globals__["os"].path,
+            "isfile",
+            fake_isfile,
+        )
+
+        result = qq_module.dispatch_media_file(
+            source_path,
+            map_path=lambda _: mapped_path,
+        )
+
+        assert len(result) == 1
+        assert type(result[0]).__name__ == "Video"
+        assert result[0].value == source_path
+
     def test_video_path_mapping_uses_valid_file_uri_for_posix_path(self, sender):
         sender._map_path = lambda p: "/plugin_data/video.mp4"
 
@@ -221,6 +250,35 @@ class TestDispatchMediaFile:
         assert result[0].file == "/mapped/report.txt"
         assert result[0].name == "report.txt"
 
+    def test_dispatch_media_file_falls_back_to_source_when_mapped_path_missing(
+        self, qq_module, monkeypatch
+    ):
+        source_path = "/tmp/report.txt"
+        mapped_path = "/mapped/report.txt"
+
+        def fake_isfile(path):
+            if path == source_path:
+                return True
+            if path == mapped_path:
+                return False
+            return False
+
+        monkeypatch.setattr(
+            qq_module.dispatch_media_file.__globals__["os"].path,
+            "isfile",
+            fake_isfile,
+        )
+
+        result = qq_module.dispatch_media_file(
+            source_path,
+            map_path=lambda _: mapped_path,
+        )
+
+        assert len(result) == 1
+        assert type(result[0]).__name__ == "File"
+        assert result[0].file == source_path
+        assert result[0].name == "report.txt"
+
     @pytest.mark.asyncio
     async def test_patch_file_to_dict_uses_object_setattr_for_strict_models(self):
         previous_modules = plugin_conftest._register_mock_package_tree()
@@ -257,6 +315,64 @@ class TestDispatchMediaFile:
                 "file": "/plugin_data/demo/mapped.apk",
             },
         }
+
+
+class TestMediaDownloader:
+    @pytest.mark.asyncio
+    async def test_download_media_skips_video_over_100mb_even_without_max_size_limit(
+        self, qq_module
+    ):
+        downloader_path = (
+            Path(plugin_conftest._repo_root) / "core" / "downloader.py"
+        )
+        spec = importlib.util.spec_from_file_location(
+            "astrbot_plugin_telegram_forwarder.core.downloader",
+            str(downloader_path),
+        )
+        downloader_module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(downloader_module)
+
+        client = MagicMock()
+        client.is_connected.return_value = True
+        client.download_media = AsyncMock(return_value="/tmp/video.mp4")
+
+        downloader = downloader_module.MediaDownloader(
+            client=client,
+            plugin_data_dir="/tmp",
+        )
+
+        msg = type(
+            "Msg",
+            (),
+            {
+                "id": 1001,
+                "media": type(
+                    "Media",
+                    (),
+                    {
+                        "document": type(
+                            "Document",
+                            (),
+                            {
+                                "size": 101 * 1024 * 1024,
+                                "attributes": [],
+                            },
+                        )()
+                    },
+                )(),
+                "photo": None,
+                "video": object(),
+                "audio": None,
+                "voice": None,
+                "file": type("FileMeta", (), {"size": 101 * 1024 * 1024})(),
+                "sticker": None,
+            },
+        )()
+
+        files = await downloader.download_media(msg, max_size_mb=0)
+
+        assert files == []
+        client.download_media.assert_not_awaited()
 
 
 class TestGetSenderDisplayName:


### PR DESCRIPTION
## Summary
- Add QQ video hard limit (100MB) in `core/downloader.py` to skip oversized Telegram videos before send.
- Add mapped-path existence fallback in `core/senders/qq_media.py` for both `Video` and generic `File` components.
- Add regression tests in `tests/test_qq_sender.py` for oversized-video skip and mapped-path fallback behavior.

## Test plan
- [x] `pytest tests/test_qq_sender.py -k \"mapped_path_missing or over_100mb\" -v`
- [x] `pytest tests/test_qq_sender.py -k \"not cleanup_processed_batches_does_not_remove_untracked_original_file\" -v`
- [ ] Full `pytest tests/test_qq_sender.py -v` (blocked by local Windows temp-dir permission issue: `WinError 5` on `tmp_path` fixture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)