### PR TITLE
[codex] fix AstrBot minimum version

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -8,4 +8,4 @@ repo: https://github.com/HSJ-BanFan/astrbot_plugin_telegram_forwarder
 support_platforms:
   - aiocqhttp
   - telegram
-astrbot_version: ">=4.13.0,<5"
+astrbot_version: ">=4.26.0,<5"

--- a/pages/dashboard/index.html
+++ b/pages/dashboard/index.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Telegram Forwarder</title>
-    <link rel="stylesheet" href="./assets/style.css?v=788a066d37" />
-    <script src="./assets/js/gsap.min.js?v=788a066d37"></script>
+    <link rel="stylesheet" href="./assets/style.css?v=0430b60ada" />
+    <script src="./assets/js/gsap.min.js?v=0430b60ada"></script>
   </head>
   <body>
     <div class="bg-aurora" aria-hidden="true"><i></i><i></i></div>
@@ -403,6 +403,6 @@
 
     <div class="toast" id="toast"></div>
     <script src="/api/plugin/page/bridge-sdk.js"></script>
-    <script src="./assets/app.js?v=788a066d37" type="module" defer></script>
+    <script src="./assets/app.js?v=0430b60ada" type="module" defer></script>
   </body>
 </html>

--- a/tests/test_metadata_compatibility.py
+++ b/tests/test_metadata_compatibility.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _astrbot_version_specifier() -> SpecifierSet:
+    for line in (ROOT / "metadata.yaml").read_text(encoding="utf-8").splitlines():
+        if line.startswith("astrbot_version:"):
+            _, raw_specifier = line.split(":", 1)
+            return SpecifierSet(raw_specifier.strip().strip("\"'"))
+    raise AssertionError("metadata.yaml must declare astrbot_version")
+
+
+def test_metadata_requires_astrbot_web_api_host_version() -> None:
+    specifier = _astrbot_version_specifier()
+
+    assert Version("4.25.6") not in specifier
+    assert Version("4.26.0") in specifier

--- a/web/index.html
+++ b/web/index.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Telegram Forwarder</title>
-    <link rel="stylesheet" href="/assets/style.css?v=788a066d37" />
-    <script src="/assets/js/gsap.min.js?v=788a066d37"></script>
+    <link rel="stylesheet" href="/assets/style.css?v=0430b60ada" />
+    <script src="/assets/js/gsap.min.js?v=0430b60ada"></script>
   </head>
   <body>
     <div class="bg-aurora" aria-hidden="true"><i></i><i></i></div>
@@ -419,6 +419,6 @@
     </div>
 
     <div class="toast" id="toast"></div>
-    <script src="/assets/app.js?v=788a066d37" type="module" defer></script>
+    <script src="/assets/app.js?v=0430b60ada" type="module" defer></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

- raise `astrbot_version` from `>=4.13.0,<5` to `>=4.26.0,<5`
- add a regression test that rejects AstrBot 4.25.6 while accepting 4.26.0

## Root cause

The plugin imports `astrbot.api.web` at module load time, but that API is unavailable in stable AstrBot releases before 4.26.0. The metadata still advertised compatibility with 4.13.0+, so older hosts accepted installation and then failed to load the plugin.

## Validation

- regression test observed failing before the metadata change and passing afterward
- `python -m pytest -q` — 375 passed
- `python -m ruff format --check tests/test_metadata_compatibility.py`
- `python -m ruff check tests/test_metadata_compatibility.py`
- `python -m compileall -q core common tests main.py relogin.py`

Closes #50

## Summary by Sourcery

Update AstrBot minimum compatible version and add a regression test to enforce host version requirements.

Bug Fixes:
- Correct AstrBot minimum version metadata to avoid installation on incompatible hosts.

Tests:
- Add a compatibility test ensuring metadata excludes AstrBot 4.25.6 and includes 4.26.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Updated the minimum supported AstrBot version to 4.26.0 while retaining compatibility with versions below 5.

* **Tests**
  * Added coverage to verify supported and unsupported AstrBot version ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->